### PR TITLE
Vicharak/Axon: Enable missing PCA9554 support

### DIFF
--- a/edk2-rockchip/Platform/Vicharak/Axon/Axon.dsc
+++ b/edk2-rockchip/Platform/Vicharak/Axon/Axon.dsc
@@ -35,8 +35,15 @@
   DEFINE RK_RTC8563_ENABLE = TRUE
 
   #
+  # PCA95XX GPIO extender support
+  # I2C location configured by PCDs below.
+  #
+  DEFINE RK_PCA95XX_ENABLE = TRUE
+
+  #
   # RK3588-based platform
   #
+
 !include Silicon/Rockchip/RK3588/RK3588Platform.dsc.inc
 
 ################################################################################
@@ -63,14 +70,17 @@
   gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-axon-linux.dtb"
 
   # I2C
-  gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }
-  gRockchipTokenSpaceGuid.PcdI2cSlaveBuses|{ 0x0, 0x0, 0x0 }
-  gRockchipTokenSpaceGuid.PcdI2cSlaveBusesRuntimeSupport|{ FALSE, FALSE, TRUE }
+  gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51, 0x24 }
+  gRockchipTokenSpaceGuid.PcdI2cSlaveBuses|{ 0x0, 0x0, 0x0, 0x6 }
+  gRockchipTokenSpaceGuid.PcdI2cSlaveBusesRuntimeSupport|{ FALSE, FALSE, TRUE, FALSE }
   gRockchipTokenSpaceGuid.PcdRk860xRegulatorAddresses|{ 0x42, 0x43 }
   gRockchipTokenSpaceGuid.PcdRk860xRegulatorBuses|{ 0x0, 0x0 }
   gRockchipTokenSpaceGuid.PcdRk860xRegulatorTags|{ $(SCMI_CLK_CPUB01), $(SCMI_CLK_CPUB23) }
   gPcf8563RealTimeClockLibTokenSpaceGuid.PcdI2cSlaveAddress|0x51
   gRockchipTokenSpaceGuid.PcdRtc8563Bus|0x0
+  gRockchipTokenSpaceGuid.PcdPca95xxAddress|0x24
+  gRockchipTokenSpaceGuid.PcdPca95xxBus|0x6
+  gRockchipTokenSpaceGuid.PcdPca95xxType|"PCA9554"
 
   #
   # CPU Performance default values

--- a/edk2-rockchip/Platform/Vicharak/Axon/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Vicharak/Axon/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -297,39 +297,20 @@ I2cIomux (
 {
   switch (id) {
     case 0:
-      /* io mux M2 */
-      PMU2_IOC->GPIO0D_IOMUX_SEL_L =
-        // write_enable
-        (0x0FF0UL << 16) |
-        // I2C0_SDA_M2, I2C0_SCL_M2
-        (0x0330);
+      GpioPinSetFunction (0, GPIO_PIN_PD1, 3); // I2C0_SCL_M2
+      GpioPinSetFunction (0, GPIO_PIN_PD2, 3); // I2C0_SDA_M2
       break;
     case 1:
-      /* io mux M2 */
-      BUS_IOC->GPIO0D_IOMUX_SEL_H =
-        // write_enable
-        (0x00FFUL << 16) |
-        // I2C1_SDA_M2, I2C1_SCL_M2
-        (0x0099);
-      PMU2_IOC->GPIO0D_IOMUX_SEL_H =
-        // write_enable
-        (0x00FFUL << 16) |
-        // I2C1_SDA_M2, I2C1_SCL_M2
-        (0x0088);
-      break;
-    case 2:
+      GpioPinSetFunction (0, GPIO_PIN_PD4, 9); // I2C1_SCL_M2
+      GpioPinSetFunction (0, GPIO_PIN_PD5, 9); // I2C1_SDA_M2
       break;
     case 3:
-      break;
-    case 4:
-      break;
-    case 5:
+      GpioPinSetFunction (1, GPIO_PIN_PC1, 9); // I2C3_SCL_M0
+      GpioPinSetFunction (1, GPIO_PIN_PC0, 9); // I2C3_SDA_M0
       break;
     case 6:
-      break;
-    case 7:
-      break;
-    case 8:
+      GpioPinSetFunction (0, GPIO_PIN_PD0, 9); // I2C6_SCL_M0
+      GpioPinSetFunction (0, GPIO_PIN_PC7, 9); // I2C6_SDA_M0
       break;
     default:
       break;


### PR DESCRIPTION
This commit adds the necessary PCDs to enable the PCA9554 GPIO expander, which is required to support USB Type-C functionality on the Axon.

Fixes: 461d0538db5814dc4bb19c61a3f14aa25ddc76fa ("Add USB Type-C support for Axon") #7 